### PR TITLE
Fix arity issue when calling make-random-clisk-file

### DIFF
--- a/src/clevolution/core.clj
+++ b/src/clevolution/core.clj
@@ -46,7 +46,7 @@
     (make-random-clisk-file output-file-path index default-depth))
   ([output-file-path index depth]
     (let [output-uri (uri-for-index output-file-path index)]
-      (save-clisk-image (random-clisk-string) output-uri))))
+      (save-clisk-image (random-clisk-string depth) output-uri))))
 
 (defn get-generator-string
   [source]


### PR DESCRIPTION
make-random-clisk-file calls random-clisk-string without an argument, resulting in arity exception. 

Added arity overloading in both make-random-clisk-file and random-clisk-string; uses default depth of 2 if not specified. Updated sample usage to illustrate.
